### PR TITLE
fix: remove redundant restart button from config dashboard

### DIFF
--- a/src/components/BotDetail.tsx
+++ b/src/components/BotDetail.tsx
@@ -322,7 +322,6 @@ export function BotDetail({ bot, onBack, tabChangeRef }: BotDetailProps) {
                 isRunning={isRunning}
                 agentType={bot.agent_type}
                 onSwitchToTerminal={() => setActiveTab("terminal")}
-                onRestart={() => restartBot(bot.id).catch((e) => setError(String(e)))}
               />
             </ErrorBoundary>
           )}

--- a/src/components/ConfigDashboard.tsx
+++ b/src/components/ConfigDashboard.tsx
@@ -31,7 +31,6 @@ interface ConfigDashboardProps {
   isRunning: boolean;
   agentType?: AgentType;
   onSwitchToTerminal: () => void;
-  onRestart?: () => void;
 }
 
 export function ConfigDashboard({
@@ -39,7 +38,6 @@ export function ConfigDashboard({
   isRunning,
   agentType,
   onSwitchToTerminal,
-  onRestart,
 }: ConfigDashboardProps) {
   const configureCmd = agentType === "Hermes" ? "hermes setup" : "openclaw configure";
   const [configs, setConfigs] = useState<Record<string, string>>({});
@@ -175,16 +173,6 @@ export function ConfigDashboard({
           </span>
         </div>
         <div className="flex items-center gap-2">
-          {isRunning && onRestart && (
-            <button
-              className="inline-flex items-center gap-1 rounded-md bg-amber-600 px-2 py-0.5 text-[10px] font-medium text-white hover:bg-amber-700"
-              onClick={() => { onRestart(); setTimeout(fetchConfig, 2000); }}
-              title="Restart bot to apply configuration changes"
-            >
-              <RefreshCw className="h-2.5 w-2.5" />
-              Restart to apply
-            </button>
-          )}
           <button
             className="text-[11px] text-[var(--badge-amber-text)] hover:opacity-80"
             onClick={() => setShowRaw(true)}


### PR DESCRIPTION
## Summary
- Removed the "Restart to apply" button from the config dashboard tab — it's redundant since restart is available from the main bot controls
- Cleaned up the unused `onRestart` prop from `ConfigDashboard`

## Test plan
- [ ] Open a running bot's config tab and verify the orange "Restart to apply" button is gone
- [ ] Verify the Raw and Refresh buttons still work
- [ ] `pnpm exec tsc -b` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)