### PR TITLE
release: v0.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ClawPier is a macOS desktop app for managing sandboxed OpenClaw bot instances via Docker. Built with Tauri v2 (Rust backend + React frontend).
+ClawPier is a macOS desktop app for managing sandboxed [OpenClaw](https://github.com/openclaw/openclaw) and [Hermes](https://github.com/NousResearch/hermes-agent) AI agent instances via Docker. Built with Tauri v2 (Rust backend + React frontend).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@
 [![Stars](https://img.shields.io/github/stars/SebastianElvis/clawpier)](https://github.com/SebastianElvis/clawpier/stargazers)
 [![Built with Tauri](https://img.shields.io/badge/built%20with-Tauri%20v2-orange)](https://v2.tauri.app)
 
-A native desktop app for managing [OpenClaw](https://github.com/openclaw) and [Hermes](https://github.com/nousresearch/hermes-agent) AI agent instances inside Docker containers — sandboxed from your host by default. Available on macOS, Linux, and Windows.
+A native desktop app for managing [OpenClaw](https://github.com/openclaw/openclaw) and [Hermes](https://github.com/NousResearch/hermes-agent) AI agent instances inside Docker containers — sandboxed from your host by default. Available on macOS, Linux, and Windows.
 
 <p align="center">
   <img src="docs/demo.gif" alt="ClawPier demo" width="800" />
   <br />
-  <sub><a href="https://github.com/SebastianElvis/clawpier/releases/download/v0.3.0/clawpier-demo.mov">&#9654; Watch full demo (60s)</a></sub>
+  <sub><a href="https://github.com/SebastianElvis/clawpier/releases/download/v0.4.1/clawpier-demo.mov">&#9654; Watch full demo (60s)</a></sub>
 </p>
 
 ## Why ClawPier?
 
-AI agent runtimes like OpenClaw and Hermes have OS-level access to your email, calendars, files, and messaging platforms. Running them directly on your host means a prompt injection gives an attacker your machine ([CVE-2026-25253](https://nvd.nist.gov/vuln/detail/CVE-2026-25253), CVSS 8.8).
+AI agent runtimes like [OpenClaw](https://github.com/openclaw/openclaw) and [Hermes](https://github.com/NousResearch/hermes-agent) have OS-level access to your email, calendars, files, and messaging platforms. Running them directly on your host means a prompt injection gives an attacker your machine ([CVE-2026-25253](https://nvd.nist.gov/vuln/detail/CVE-2026-25253), CVSS 8.8).
 
 ClawPier fixes this by running every agent inside a Docker container:
 
@@ -51,12 +51,12 @@ Grab the latest build for your platform from [Releases](https://github.com/Sebas
 ### Prerequisites
 
 - **Docker** must be installed and running (Docker Desktop on macOS/Windows, or Docker Engine on Linux)
-- Agent Docker image (OpenClaw or Hermes) — ClawPier will prompt you to pull it on first launch
+- Agent Docker image ([OpenClaw](https://github.com/openclaw/openclaw) or [Hermes](https://github.com/NousResearch/hermes-agent)) — ClawPier will prompt you to pull it on first launch
 
 ## Features
 
 ### Multi-Agent Support
-- **OpenClaw and Hermes** — choose your agent runtime when creating a bot
+- **[OpenClaw](https://github.com/openclaw/openclaw) and [Hermes](https://github.com/NousResearch/hermes-agent)** — choose your agent runtime when creating a bot
 - **Agent-specific config dashboards** — view model, provider, platforms, and settings per agent type
 - **Image pull progress** — real-time progress bar with layer and byte tracking
 

--- a/dev/ROADMAP.md
+++ b/dev/ROADMAP.md
@@ -8,7 +8,7 @@
 
 **The Desktop Control Plane for Local AI Agents.**
 
-ClawPier makes running and managing personal AI agents as easy as managing apps on your phone. It is the GUI layer that makes a powerful-but-complex agent runtime accessible — and the orchestration platform that makes multiple agents work together.
+ClawPier makes running and managing personal AI agents ([OpenClaw](https://github.com/openclaw/openclaw), [Hermes](https://github.com/NousResearch/hermes-agent), and more) as easy as managing apps on your phone. It is the GUI layer that makes a powerful-but-complex agent runtime accessible — and the orchestration platform that makes multiple agents work together.
 
 **ClawPier is to AI agents what Docker Desktop is to Docker.** It already supports OpenClaw and Hermes, with a pluggable architecture ready for more runtimes.
 
@@ -18,7 +18,7 @@ ClawPier makes running and managing personal AI agents as easy as managing apps 
 
 ### The Problem
 
-Running self-hosted AI agents (OpenClaw, Hermes, etc.) today requires: Docker knowledge, CLI fluency, config file editing, manual monitoring, and juggling multiple terminal sessions. This limits adoption to technical users willing to invest setup time.
+Running self-hosted AI agents ([OpenClaw](https://github.com/openclaw/openclaw), [Hermes](https://github.com/NousResearch/hermes-agent), etc.) today requires: Docker knowledge, CLI fluency, config file editing, manual monitoring, and juggling multiple terminal sessions. This limits adoption to technical users willing to invest setup time.
 
 ### The Moat
 
@@ -62,7 +62,7 @@ Go from managing one bot to managing a fleet. Agent templates, inter-agent commu
 
 **Target:** Power users building personal AI workflows.
 
-**Status after v0.4.0:**
+**Status after v0.4.1:**
 - [x] Multi-runtime support — Hermes agent alongside OpenClaw (agent-specific config, images, dashboards)
 - [x] Image pull progress streaming with per-layer tracking
 - [ ] Visual config editor (replace `openclaw configure`)
@@ -82,7 +82,7 @@ Support agent runtimes beyond OpenClaw. Become the "Raycast for AI agents" — a
 
 **Target:** Anyone who wants AI agents working for them.
 
-- [x] First non-OpenClaw runtime: Hermes agent (shipped in v0.4.0)
+- [x] First non-OpenClaw runtime: Hermes agent (shipped in v0.4.1)
 - [ ] Pluggable runtime adapters (AutoGPT, CrewAI, custom containers)
 - [ ] Agent marketplace — install community-built agent configs
 - [ ] Cross-platform (Windows, Linux) — Tauri already supports this

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clawpier",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "clawpier"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "bollard",
  "bytes",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clawpier"
-version = "0.4.0"
+version = "0.4.1"
 description = "OpenClaw Manager - Manage sandboxed OpenClaw bot instances"
 authors = ["Runchao Han"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "ClawPier",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "identifier": "com.clawpier.manager",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,6 +1,28 @@
 import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
+// Provide a working localStorage for zustand persist middleware.
+// jsdom's built-in localStorage can be incomplete in some versions.
+const store: Record<string, string> = {};
+const localStorageMock: Storage = {
+  getItem: (key: string) => store[key] ?? null,
+  setItem: (key: string, value: string) => {
+    store[key] = value;
+  },
+  removeItem: (key: string) => {
+    delete store[key];
+  },
+  clear: () => {
+    for (const key of Object.keys(store)) delete store[key];
+  },
+  get length() {
+    return Object.keys(store).length;
+  },
+  key: (index: number) => Object.keys(store)[index] ?? null,
+};
+Object.defineProperty(globalThis, "localStorage", { value: localStorageMock, writable: true });
+Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+
 // Mock @tauri-apps/api/core
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),


### PR DESCRIPTION
## Summary
- Bump version to 0.4.1 in package.json, Cargo.toml, tauri.conf.json
- Add [OpenClaw](https://github.com/openclaw/openclaw) and [Hermes](https://github.com/NousResearch/hermes-agent) repo links to README, CLAUDE.md, and ROADMAP
- Fix localStorage mock in test setup for zustand persist middleware (was causing 25 test failures)

## Test plan
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc -b` — clean
- [x] `pnpm test` — 167/167 passed
- [x] `cargo test` — 187/187 passed
- [x] `cargo check --release` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)